### PR TITLE
crypto_generichash_blake2b_salt_personal method signature mismatch

### DIFF
--- a/src/main/java/com/goterl/lazycode/lazysodium/Sodium.java
+++ b/src/main/java/com/goterl/lazycode/lazysodium/Sodium.java
@@ -729,7 +729,7 @@ public class Sodium {
             long inLen,
             byte[] masterKey,
             int masterKeyLen,
-            long subKeyId,
+            byte[] subKeyId,
             byte[] context
     );
 


### PR DESCRIPTION
"crypto_generichash_blake2b_salt_personal" declares subKeyId param as a long, which doesn't match libsodium's const unsigned char *salt, const unsigned char *personal for subKeyId and context. Attempting to invoke the method on linux64 crashed the JVM. Changing the signature and loading the bundled *.so file in to a new class with the modified sig from this commit fixed the crash and produced the expected hash.